### PR TITLE
Migrate from AWS DynamoDB to Github Artifacts

### DIFF
--- a/src/lib/translation-storage/translationStorage.ts
+++ b/src/lib/translation-storage/translationStorage.ts
@@ -2,7 +2,13 @@ import { DeleteCommand, DynamoDBDocumentClient, GetCommand, PutCommand } from "@
 import { SnapshotData } from "../snapshot.js";
 import { TranslationKey } from "../translation-key.js";
 
-export class Storage {
+export interface Storage {
+	uploadTranslations(keys: TranslationKey[]): Promise<void> ;
+	downloadTranslations(): Promise<TranslationKey<SnapshotData>[]> ;
+	removeTranslations(): Promise<void> ;
+}
+
+export class _Storage {
 	constructor(
 		private readonly documentClient: DynamoDBDocumentClient,
 		private readonly tableName: string,
@@ -35,7 +41,7 @@ export class Storage {
 		return response.Item?.terms ?? [];
 	}
 
-	public async removeTranslations() {
+	public async removeTranslations(): Promise<void> {
 		await this.documentClient.send(
 			new DeleteCommand({
 				TableName: this.tableName,


### PR DESCRIPTION
# New storage
DynamoDB seemed to be such a good idea to store the translations. Only to discover that the limit of a record is 400KB. Due to this, I switched back to my initial idea to use github artifacts.

Github artifacts have their own difficulties (read: problems 😉), mainly that they don't share artifacts between workflows. This will be necessary for the intented use of this action. The problem can be solved by two different apis to upload and download artifacts.

# Mocks 
Another reason I preferred DynamoDB was that is was possible to use it using the `Act` Github Actions runner, which cannot be said of Artifacts. To speed up development I created local mocks for the Github PR and Artifact interaction