### PR TITLE
Correctly handle special case for < and > in xliff2-writer

### DIFF
--- a/__tests__/lib/translation-files/writers/xliff2-writer.test.ts
+++ b/__tests__/lib/translation-files/writers/xliff2-writer.test.ts
@@ -151,11 +151,11 @@ test('XLIFF2 special chars', async () => {
 			originalId: "1332434532",
 			translations: [
 				{
-					translation: "This is a test & more ©",
+					translation: "This is a &lt; test & more ©",
 					language: "en-US",
 				},
 				{
-					translation: "Dit is een test & meer ©",
+					translation: "Dit is een &gt; test & meer ©",
 					language: "nl",
 				},
 			],
@@ -171,8 +171,8 @@ test('XLIFF2 special chars', async () => {
   <file original="ng.template" id="ngi18n">
     <unit id="1332434532">
       <segment state="final">
-        <source>This is a test &amp; more &#xa9;</source>
-        <target>Dit is een test &amp; meer &#xa9;</target>
+        <source>This is a &lt; test &amp; more &#xa9;</source>
+        <target>Dit is een &gt; test &amp; meer &#xa9;</target>
       </segment>
     </unit>
   </file>

--- a/src/commands/extract-translations-and-store-command.ts
+++ b/src/commands/extract-translations-and-store-command.ts
@@ -22,6 +22,7 @@ export class ExtractTranslationsAndStoreCommand implements Command {
 		info(`Read keys from input files`);
 		const inputKeys = await this.parseTermsFiles();
 		const uniqueKeys = this.unique<SnapshotData>(inputKeys);
+		info(`Read ${inputKeys.length} keys, of which ${uniqueKeys.length} were unique`);
 
 		info(`Fetch keys currently stored in the TMS`);
 		const tmsKeys = await this.tmsClient.getKeys();
@@ -47,7 +48,7 @@ export class ExtractTranslationsAndStoreCommand implements Command {
 	private async parseTermsFiles(): Promise<ExtractedKey<SnapshotData>[]> {
 		let keys: ExtractedKey<SnapshotData>[] = [];
 		for (const source of this.configuration.terms) {
-			const reader = await ReaderFactory.factory(source.type);
+			const reader = ReaderFactory.factory(source.type);
 			const input = await readFile(source.terms, 'utf-8');
 
 			const associatedSnapshotData = this.configuration.snapshots.find(

--- a/src/lib/translation-files/readers/xliff2-reader.ts
+++ b/src/lib/translation-files/readers/xliff2-reader.ts
@@ -137,11 +137,7 @@ export class Xliff2Reader implements TermsReader {
 	}
 
 	private parseSource(source: SourceXmlNode[]): string {
-		TranslationXml.traverseTextNodes(source, (text) => {
-			return decode(text, EntityLevel.HTML)
-				.replace("<", "&lt;")
-				.replace(">", "&gt;");
-		});
+		TranslationXml.traverseTextNodes(source, (text) => TranslationXml.decode(text));
 
 		return TranslationXml.xmlTreeToString(source);
 	}

--- a/src/lib/translation-files/shared/xliff2/translation-xml.ts
+++ b/src/lib/translation-files/shared/xliff2/translation-xml.ts
@@ -1,3 +1,4 @@
+import { decode, encode, EntityLevel } from "entities";
 import { XMLBuilder, XMLParser } from "fast-xml-parser";
 
 export type SourceXmlNode = Record<string, SourceXmlNode[]> & {
@@ -61,5 +62,15 @@ export class TranslationXml {
 				}
 			}
 		}
+	}
+
+	public static encode(text: string): string {
+		let preparsed = text.replace("&lt;", "<").replace("&gt;", ">");
+		return encode(preparsed, EntityLevel.XML);
+	}
+
+	public static decode(text: string): string {
+		const decoded = decode(text, EntityLevel.HTML);
+		return decoded.replace("<", "&lt;").replace(">", "&gt;");
 	}
 }

--- a/src/lib/translation-files/writers/xliff2-writer.ts
+++ b/src/lib/translation-files/writers/xliff2-writer.ts
@@ -88,7 +88,7 @@ export class Xliff2Writer implements TermsWriter {
 	private encodeHtml(input: string): string {
 		const tree = TranslationXml.stringToXmlTree(`<root>${input}</root>`, true);
 
-		TranslationXml.traverseTextNodes(tree, (text) => encode(text, EntityLevel.XML));
+		TranslationXml.traverseTextNodes(tree, (text) => TranslationXml.encode(text));
 
 		return TranslationXml.xmlTreeToString(tree);
 	}


### PR DESCRIPTION
Correctly handle special case for < and > in xliff2-writer

< and > were being read as &lt; and &gt;
they were then written as &amp;lt; and &amp;gt;

This fix makes sure the writer has the same special case for these
characters as the reader does